### PR TITLE
Insert missing `s` for the route

### DIFF
--- a/_posts/2015-08-23-type-safe-web-services-in-haskell-with-servant.md
+++ b/_posts/2015-08-23-type-safe-web-services-in-haskell-with-servant.md
@@ -35,7 +35,7 @@ type API
     -- GET /things
     = "things" :> Get '[JSON] [Thing]
     -- GET /things/:id
-    :<|> "thing" :> Capture "id" Integer :> Get '[JSON] Thing
+    :<|> "things" :> Capture "id" Integer :> Get '[JSON] Thing
 ```
 
 That describes two endpoints, `GET /things` and `GET /things/:id`.


### PR DESCRIPTION
If I'm not mistaken, that string was supposed to be `"things"` not `"thing"` because the route is `GET /things/:id`